### PR TITLE
Re-enable auto publishing for store.korge, but only "at 22:00, on day 1 of the month. " instead of every day

### DIFF
--- a/.github/workflows/updateall.yml
+++ b/.github/workflows/updateall.yml
@@ -2,8 +2,9 @@ name: Update All repositories and search for new versions
  
 on:
   # https://crontab.guru/#0_10,22_*_*_*
+  push:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 22 1 * *'
     #- cron: '0 10,22 * * *'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Needed for publishing latest virtual controller package for example. (workflow got disabled as there is no activity 5 months ago) As there is little activity, one month cycle should be enough